### PR TITLE
v1.1.0: rename to ruby-gem-setup-github-packages-action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [1.1.0] - 2021-04-15
+
+- Change: name to ruby-gem-setup-github-packages-action. Old name still works due too GH redirects.
+
 ## [1.0.0] - 2021-04-14
 
 - Add: Action that can log into github package registry using a passed (github or other) token.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# RubyGems Setup GitHub Package Registry Action
+# Ruby Gem - Setup GitHub Packages
 
 ## Description
 
-This action will setup ruby gem access (the `~/.gem/credentials` file) for the GitHub Package Registry. If you pushing a gem to the same repo, all it needs is the default github actions token.
+This action will setup ruby gem access (the `~/.gem/credentials` file) for GitHub Packages. If your pushing a gem to the same repo as it builds in, all it needs is the default GitHub actions token.
 
-The key is added under the name `github` and we also set environment variables (`GEM_HOST_API_KEY` and `GEM_HOST`) that can be used to push gems. You can do this your self, but the action is designed to also be used with the [fac/rubygems-push-action](https://github.com/fac/rubygems-push-action).
+The key is added under the name `github` and we also set environment variables (`GEM_HOST_API_KEY` and `GEM_HOST`) that can be used to push gems. You can do this your self, but the action is also designed to be used with the [fac/ruby-gem-push-action](https://github.com/fac/ruby-gem-push-action).
 
 ## Usage
 
@@ -18,12 +18,12 @@ The key is added under the name `github` and we also set environment variables (
       run: bundle exec rake build
 
     - name: Setup GPR
-      uses: fac/rubygems-setup-gpr-action@v1
+      uses: fac/ruby-gem-setup-github-packages-action@v1
       with:
         token: ${{ secrets.github_token }}
 
     - name: Push Gem
-      uses: fac/rubygems-push-action@v1
+      uses: fac/ruby-gem-push-action@v1
 ```
 
 If you want to use your own push or other customizations:
@@ -46,7 +46,7 @@ The token to be used for authenticating with GitHub packages. If you are pushing
 
 ```yaml
 with:
-   token: ${{ secrets.package_token }}
+   token: ${{ secrets.github_token }}
 ```
 
 ## Outputs

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: RubyGems Setup GitHub Package Registry
+name: Ruby Gem Setup GitHub Packages
 author: FreeAgent
-description: Configure ruby gem to access GPR (GitHub Package Registry)
+description: Configure ruby gem to access GitHub Packages
 inputs:
   token:
-    description: "Token to access the GitHub package registry. Normally using secrets.github_token is enough."
+    description: "Token to access GitHub packages. Normally using secrets.github_token is enough."
     required: true
 
 runs:


### PR DESCRIPTION
The previous naming was confusing and contentious. The GPR acronym is
oddly hard to remember, not that widly used and I'm even unsure if the
R is registry or repository! Fix this by just calling it github-packages
and not using any abbreviations.

Additionally rubygems- made it look like it was for the actual rubygems
site and registry. The intention was to show this is a ruby action
dealing with gems. Changing the prefix to `ruby-gem-` to fix that.

Note this also updates the name for ruby-gem-push-action in the docs,
as that is due to be renamed to match this convention.

See: fac/dev-platform#62