### PR TITLE
Use keyname not GEM_HOST_API_KEY by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-04-26
+
+- Change: Don't export the token in the environment by default, users should use the key name.
+- Add: Input `key` to set the key name, defaults to `github`.
+- Add: Input `export-token` to control exporting the environment, default false.
+
 ## [1.1.0] - 2021-04-15
 
 - Change: name to ruby-gem-setup-github-packages-action. Old name still works due too GH redirects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [2.0.0] - 2021-04-26
 
+- Change: Name change to `ruby-gem-setup-credentials` from `ruby-gem-setup-github-packages-action`
 - Change: Don't export the token in the environment by default, users should use the key name.
 - Add: Input `key` to set the key name, defaults to `github`.
 - Add: Input `export-token` to control exporting the environment, default false.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Ruby Gem - Setup GitHub Packages
+# Ruby Gem - Setup Credentials Action
 
 ## Description
 
-This action will setup ruby gem access (the `~/.gem/credentials` file) for GitHub Packages. If your pushing a gem to the same repo as it builds in, all it needs is the default GitHub actions token.
+This action will setup ruby gem access (the `~/.gem/credentials` file) with the given token. If your pushing a gem to GH packages using the same repo as it builds in, all it needs is the default GitHub actions token. For other repos you will need to add a secret you can then pass to the input.
 
-The key is added under the name `github`. Optionally you can export environment variable `GEM_HOST_API_KEY` which is read by (more recent versions of) the `gem` command. However we advise you to be explicit and pass the key name `github` as an input or argument instead.
+The key is added under the name `github` by default, change with the `key` input. Optionally you can export environment variable `GEM_HOST_API_KEY` which is read by (more recent versions of) the `gem` command. However we advise you to be explicit and pass the key name `github` as an input or argument instead.
 
-You can do gem push your self, but the action is also designed to be used with the [fac/ruby-gem-push-action](https://github.com/fac/ruby-gem-push-action).
+You can do the gem push your self, but the action is also designed to be used with the [fac/ruby-gem-push-action](https://github.com/fac/ruby-gem-push-action).
 
 ## Usage
 
@@ -20,19 +20,19 @@ You can do gem push your self, but the action is also designed to be used with t
       run: bundle exec rake build
 
     - name: Setup GPR
-      uses: fac/ruby-gem-setup-github-packages-action@v2
+      uses: fac/ruby-gem-setup-credentials-action@v2
       with:
         token: ${{ secrets.github_token }}
 
     - name: Push Gem
-      uses: fac/ruby-gem-push-action@v1
+      uses: fac/ruby-gem-push-action@v2
 ```
 
 If you want to use your own push or other customizations:
 
 ```yaml
     - name: Setup GPR
-      uses: fac/ruby-gem-setup-github-packages-action@v2
+      uses: fac/ruby-gem-setup-credentials-action@v2
       with:
         token: ${{ secrets.package_token }}
 
@@ -51,6 +51,14 @@ with:
    token: ${{ secrets.github_token }}
 ```
 
+### key
+
+The key name to use in the credentials file. Default is `github`.
+
+### export-token
+
+Set true to export the GEM_HOST_API_KEY environment variable.
+
 ## Outputs
 
 None.
@@ -58,11 +66,8 @@ None.
 
 ### GEM_HOST_API_KEY
 
-Set for the workflow by calling the action. Contains the API key string (prefixed token with Bearer), to access the package repo. Used by `gem push`.
+Optionally exported by calling the action. Contains the API key string (prefixed token with Bearer), to access the package repo. Used by `gem push`.
 
-### GEM_HOST
-
-Set for the workflow by calling the action. The host URL for pushing gems to the package repo for the currently building repo.
 ## Authors
 
 * FreeAgent <opensource@freeagent.com>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 This action will setup ruby gem access (the `~/.gem/credentials` file) for GitHub Packages. If your pushing a gem to the same repo as it builds in, all it needs is the default GitHub actions token.
 
-The key is added under the name `github` and we also set environment variables (`GEM_HOST_API_KEY` and `GEM_HOST`) that can be used to push gems. You can do this your self, but the action is also designed to be used with the [fac/ruby-gem-push-action](https://github.com/fac/ruby-gem-push-action).
+The key is added under the name `github`. Optionally you can export environment variable `GEM_HOST_API_KEY` which is read by (more recent versions of) the `gem` command. However we advise you to be explicit and pass the key name `github` as an input or argument instead.
+
+You can do gem push your self, but the action is also designed to be used with the [fac/ruby-gem-push-action](https://github.com/fac/ruby-gem-push-action).
 
 ## Usage
 
@@ -18,7 +20,7 @@ The key is added under the name `github` and we also set environment variables (
       run: bundle exec rake build
 
     - name: Setup GPR
-      uses: fac/ruby-gem-setup-github-packages-action@v1
+      uses: fac/ruby-gem-setup-github-packages-action@v2
       with:
         token: ${{ secrets.github_token }}
 
@@ -30,12 +32,12 @@ If you want to use your own push or other customizations:
 
 ```yaml
     - name: Setup GPR
-      uses: fac/rubygems-setup-gpr-action@v1
+      uses: fac/ruby-gem-setup-github-packages-action@v2
       with:
         token: ${{ secrets.package_token }}
 
     - name: Push Gem
-      run: gem push --host "$GEM_HOST" foo.gem
+      run: gem push --key=github --host='https://rubygems.pkg.github.com/${{ github.repository_owner }}' foo.gem
 ```
 
 ## Inputs

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: Ruby Gem Setup GitHub Packages
+name: Ruby Gem Setup Credentials
 author: FreeAgent
 description: Configure ruby gem to access GitHub Packages
 inputs:

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,14 @@ inputs:
   token:
     description: "Token to access GitHub packages. Normally using secrets.github_token is enough."
     required: true
+  key:
+    description: "The name to give the key in the creds file and when calling gem push"
+    default: "github"
+    required: true
+  export-token:
+    description: "Set true to export the token (with Bearer prefix) in the GEM_HOST_API_KEY env var."
+    default: false
+    required: true
 
 runs:
   using: "composite"
@@ -17,7 +25,10 @@ runs:
         mkdir -p $HOME/.gem
         touch $HOME/.gem/credentials
         chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
 
-        echo "GEM_HOST=https://rubygems.pkg.github.com/${{ github.repository_owner }}" >> $GITHUB_ENV
-        echo "GEM_HOST_API_KEY=$GEM_HOST_API_KEY" >> $GITHUB_ENV
+        key_name='${{ inputs.key }}'
+        printf -- "---\n:$key_name: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+
+        if [[ '${{ inputs.export-token }}' == true ]]; then
+          echo "GEM_HOST_API_KEY=$GEM_HOST_API_KEY" >> $GITHUB_ENV
+        fi


### PR DESCRIPTION
- Change: Don't export the token in the environment by default, users should use the key name.
- Add: Input `key` to set the key name, defaults to `github`.
- Add: Input `export-token` to control exporting the environment, default false.

Tested: https://github.com/fac/github-scanner/pull/7

See fac/dev-platform#35