### PR TITLE
Add user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2021-05-04
+
+- Add: user input to set the user name for the token
+
 ## [2.0.0] - 2021-04-26
 
 - Change: Name change to `ruby-gem-setup-credentials` from `ruby-gem-setup-github-packages-action`

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: Ruby Gem Setup Credentials
 author: FreeAgent
 description: Configure ruby gem to access GitHub Packages
 inputs:
+  user:
+    description: "User name for the token."
+    required: true
+    default: Bearer
   token:
     description: "Token to access GitHub packages. Normally using secrets.github_token is enough."
     required: true
@@ -19,9 +23,12 @@ runs:
   steps:
     - name: Setup GPR
       shell: bash
-      env:
-        GEM_HOST_API_KEY: "Bearer ${{ inputs.token }}"
       run: |
+        if [ -n "${{ inputs.user}}" ]; then
+          GEM_HOST_API_KEY="${{ inputs.user }} ${{ inputs.token }}"
+        else
+          GEM_HOST_API_KEY="${{ inputs.token }}"
+        fi
         mkdir -p $HOME/.gem
         touch $HOME/.gem/credentials
         chmod 0600 $HOME/.gem/credentials

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,6 @@ description: Configure ruby gem to access GitHub Packages
 inputs:
   user:
     description: "User name for the token."
-    required: true
     default: Bearer
   token:
     description: "Token to access GitHub packages. Normally using secrets.github_token is enough."


### PR DESCRIPTION
Allows setting the username for the token, or in the case of rubygems
not having one at all. The default needs to be Bearer to match the
current v2 usage in all the internal gems.

See fac/dev-platform#35