### PR TITLE
Set explicit not required for user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 ## [Unreleased]
+
+## [2.1.2] - 2021-05-06
+
+- Fix: add `required` to user input configuration
+
 ## [2.1.1] - 2021-05-04
 
 - Add: docs for user input

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   user:
     description: "User name for the token."
     default: Bearer
+    required: false
   token:
     description: "Token to access GitHub packages. Normally using secrets.github_token is enough."
     required: true


### PR DESCRIPTION
Composite actions need `required` explicitly set, and won't default to `false` if it's not set!

fixed fac/dev-platform#200